### PR TITLE
add core liveness & readiness probes

### DIFF
--- a/templates/core/core.yaml
+++ b/templates/core/core.yaml
@@ -51,18 +51,19 @@ spec:
               containerPort: {{ .Values.core.port }}
           resources:
             {{- toYaml .Values.core.resources | nindent 12 }}
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          #   initialDelaySeconds: 120
-          #   timeoutSeconds: 5
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          #   initialDelaySeconds: 10
-          #   timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /server/ping
+              port: 8080
+            initialDelaySeconds: 300
+            failureThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /server/ping
+              port: 8080
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
       {{- with .Values.global.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Checked that it works in minikube. To check the liveness probe I controllably tweaked the cytomine-core pod to malfunction. I also deployed it in the "fed-cluster" without a problem.