### PR TITLE
Fix/volumeClaimName

### DIFF
--- a/templates/mongodb/mongodb.yaml
+++ b/templates/mongodb/mongodb.yaml
@@ -11,6 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: 1
+  serviceName: {{ include "cytomine.name" . }}-mongodb
   selector:
     matchLabels:
       app: {{ template "cytomine.name" . }}-mongodb
@@ -27,17 +28,13 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      volumes:
-      - name: mongodb-storage
-        persistentVolumeClaim:
-          claimName: {{ template "cytomine.name" . }}
       containers:
         - name: {{ .Chart.Name }}-mongodb
           image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
           imagePullPolicy: {{ .Values.mongodb.image.pullPolicy }}
           command: ["mongod"]
           volumeMounts:
-            - name: mongodb-storage
+            - name: {{ template "cytomine.name" . }}
               mountPath: "/data/db"
           ports:
             - name: mongodb

--- a/templates/mongodb/mongodb.yaml
+++ b/templates/mongodb/mongodb.yaml
@@ -28,13 +28,17 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      - name: mongodb-storage
+        persistentVolumeClaim:
+          claimName: {{ include "cytomine.fullname" . }}-cytomine-mongodb-0
       containers:
         - name: {{ .Chart.Name }}-mongodb
           image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
           imagePullPolicy: {{ .Values.mongodb.image.pullPolicy }}
           command: ["mongod"]
           volumeMounts:
-            - name: {{ template "cytomine.name" . }}
+            - name: mongodb-storage
               mountPath: "/data/db"
           ports:
             - name: mongodb
@@ -56,7 +60,7 @@ spec:
       {{- end }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ template "cytomine.name" . }}
+        name: {{ include "cytomine.fullname" . }}
       spec:
         storageClassName: {{ .Values.readOnceStorageClass }}
         accessModes:

--- a/templates/postgresql/postgresql.yaml
+++ b/templates/postgresql/postgresql.yaml
@@ -28,12 +28,16 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      - name: postgres-storage
+        persistentVolumeClaim:
+          claimName: {{ include "cytomine.fullname" . }}-cytomine-postgis-0
       containers:
         - name: {{ .Chart.Name }}-postgis
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           volumeMounts:
-            - name: {{ template "cytomine.name" . }}
+            - name: postgres-storage
               mountPath: "/postgres-data/"
           env:
           - name: DATA_DIR
@@ -76,7 +80,7 @@ spec:
       {{- end }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ template "cytomine.name" . }}
+        name: {{ include "cytomine.name" . }}
       spec:
         storageClassName: {{ .Values.readOnceStorageClass }}
         accessModes:

--- a/templates/postgresql/postgresql.yaml
+++ b/templates/postgresql/postgresql.yaml
@@ -11,6 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: 1
+  serviceName: {{ template "cytomine.name" . }}-postgis
   selector:
     matchLabels:
       app: {{ template "cytomine.name" . }}-postgis
@@ -27,16 +28,12 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      volumes:
-      - name: postgres-storage
-        persistentVolumeClaim:
-          claimName: {{ template "cytomine.name" . }}
       containers:
         - name: {{ .Chart.Name }}-postgis
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           volumeMounts:
-            - name: postgres-storage
+            - name: {{ template "cytomine.name" . }}
               mountPath: "/postgres-data/"
           env:
           - name: DATA_DIR


### PR DESCRIPTION
There was a problem with the MangoDB and PostgreSQL pods not being able to find the `persistentVolumeClaim` because of an incorrect `volumeClaimName` in the pod configuration. An attempt to fix the error. 