### PR TITLE
Fix volume issues

### DIFF
--- a/templates/mongodb/mongodb.yaml
+++ b/templates/mongodb/mongodb.yaml
@@ -28,10 +28,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      volumes:
-      - name: mongodb-storage
-        persistentVolumeClaim:
-          claimName: {{ include "cytomine.fullname" . }}-cytomine-postgis-0
       containers:
         - name: {{ .Chart.Name }}-mongodb
           image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"

--- a/templates/mongodb/mongodb.yaml
+++ b/templates/mongodb/mongodb.yaml
@@ -11,6 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: 1
+  serviceName: {{ include "cytomine.name" . }}-mongodb
   selector:
     matchLabels:
       app: {{ template "cytomine.name" . }}-mongodb

--- a/templates/mongodb/mongodb.yaml
+++ b/templates/mongodb/mongodb.yaml
@@ -31,7 +31,7 @@ spec:
       volumes:
       - name: mongodb-storage
         persistentVolumeClaim:
-          claimName: {{ template "cytomine.name" . }}
+          claimName: {{ include "cytomine.fullname" . }}-cytomine-postgis-0
       containers:
         - name: {{ .Chart.Name }}-mongodb
           image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
@@ -60,7 +60,7 @@ spec:
       {{- end }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ template "cytomine.name" . }}
+        name: {{ include "cytomine.fullname" . }}
       spec:
         storageClassName: {{ .Values.readOnceStorageClass }}
         accessModes:

--- a/templates/mongodb/mongodb.yaml
+++ b/templates/mongodb/mongodb.yaml
@@ -56,7 +56,7 @@ spec:
       {{- end }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ include "cytomine.fullname" . }}
+        name: mongodb-storage
       spec:
         storageClassName: {{ .Values.readOnceStorageClass }}
         accessModes:

--- a/templates/postgresql/postgresql.yaml
+++ b/templates/postgresql/postgresql.yaml
@@ -31,7 +31,7 @@ spec:
       volumes:
       - name: postgres-storage
         persistentVolumeClaim:
-          claimName: {{ template "cytomine.name" . }}
+          claimName: {{ include "cytomine.fullname" . }}-cytomine-mongodb-0
       containers:
         - name: {{ .Chart.Name }}-postgis
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
@@ -80,7 +80,7 @@ spec:
       {{- end }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ template "cytomine.name" . }}
+        name: {{ include "cytomine.fullname" . }}
       spec:
         storageClassName: {{ .Values.readOnceStorageClass }}
         accessModes:

--- a/templates/postgresql/postgresql.yaml
+++ b/templates/postgresql/postgresql.yaml
@@ -76,7 +76,7 @@ spec:
       {{- end }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ include "cytomine.fullname" . }}
+        name: postgres-storage
       spec:
         storageClassName: {{ .Values.readOnceStorageClass }}
         accessModes:

--- a/templates/postgresql/postgresql.yaml
+++ b/templates/postgresql/postgresql.yaml
@@ -28,10 +28,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      volumes:
-      - name: postgres-storage
-        persistentVolumeClaim:
-          claimName: {{ include "cytomine.fullname" . }}-cytomine-mongodb-0
       containers:
         - name: {{ .Chart.Name }}-postgis
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"

--- a/templates/postgresql/postgresql.yaml
+++ b/templates/postgresql/postgresql.yaml
@@ -11,6 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: 1
+  serviceName: {{ include "cytomine.name" . }}-mongodb
   selector:
     matchLabels:
       app: {{ template "cytomine.name" . }}-postgis


### PR DESCRIPTION
- Added missing field `serviceName` to StatefulSets manifests.
- There was a problem with the MangoDB and PostgreSQL pods not being able to find the `persistentVolumeClaim` because of an incorrect `volumeClaimName` in the pod configuration. I have updated the respective yaml files.
